### PR TITLE
remove has_rdoc attribute assignment from gemspec

### DIFF
--- a/lib/perfectsched/version.rb
+++ b/lib/perfectsched/version.rb
@@ -1,3 +1,3 @@
 module PerfectSched
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/perfectsched.gemspec
+++ b/perfectsched.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |gem|
   gem.version     = PerfectSched::VERSION
   gem.authors     = ["Sadayuki Furuhashi"]
   gem.email       = "frsyuki@gmail.com"
-  gem.has_rdoc    = false
   gem.files       = `git ls-files`.split("\n")
   gem.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
this error floated up during image building step of [dockerfile](https://github.com/kitcheck/kc-api/blob/trunk/Dockerfile#L15)
`RUN --mount=type=ssh bundle install`
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. 
It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /app/vendor/bundle/ruby/3.1.0/bundler/gems/perfectsched-7bdeb660ff92/perfectsched.gemspec:13.
```
