### PR TITLE
[BCS-7537] Add timestamps when inserting rows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    perfectsched (0.10.0)
+    perfectsched (0.11.0)
       chrono (~> 0.3.0)
       perfectqueue (>= 0.8.41, < 1.0)
       sequel (~> 4.0.0)

--- a/lib/perfectsched/backend/rdb_compat.rb
+++ b/lib/perfectsched/backend/rdb_compat.rb
@@ -117,7 +117,10 @@ module PerfectSched
         data['type'] = type
         connect {
           begin
-            n = @db["INSERT INTO `#{@table}` (id, timeout, next_time, cron, delay, data, timezone) VALUES (?, ?, ?, ?, ?, ?, ?);", key, next_run_time, next_time, cron, delay, data.to_json, timezone].insert
+            sql = "INSERT INTO `#{@table}` (id, timeout, next_time, cron, delay, data, timezone, created_at, updated_at)" \
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
+            @db[sql, key, next_run_time, next_time, cron, delay, data.to_json, timezone, Time.now.in_time_zone(timezone),
+                Time.now.in_time_zone(timezone)].insert
             return Schedule.new(@client, key)
           rescue Sequel::DatabaseError
             raise IdempotentAlreadyExistsError, "schedule key=#{key} already exists"

--- a/lib/perfectsched/version.rb
+++ b/lib/perfectsched/version.rb
@@ -1,3 +1,3 @@
 module PerfectSched
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end


### PR DESCRIPTION
When we updated DCS/PHI to MySQL 5.7, we chose to leave the Svalbard `docker-compose` at 5.6 because there was an error with registry service. I recently attempted to do so again to allow use of a JSON column in DCS and ran into the [same issue](https://buildkite.com/kit-check/svalbard/builds/83649#01870044-3f22-4195-b6fd-9910ccfbcc5a).

After debugging a bit, it turns out it's because the `perfectsched` gem doesn't update the `created_at` and `updated_at` timestamps when inserting rows. For our purposes, this is when [registry service calls](https://github.com/kitcheck/registry-service/blob/trunk/app/service_objects/tunnel_checker_manager.rb#L10-L19) `TunnelCheckManager#add_tunnel_checker`.

The error is misleading, as it throws an `IdempotentAlreadyExistsError` because of the `rescue`. However, when reviewing the full error we can see the issue.

```
rails aborted!
PerfectSched::IdempotentAlreadyExistsError: schedule key= already exists
...
stack trace
...

Caused by:
Sequel::DatabaseError: Mysql2::Error: Field 'created_at' doesn't have a default value
...
7bdeb660ff92/lib/perfectsched/backend/rdb_compat.rb:120:in `block in add'
stack trace
```

This is specifically an issues because we added the `STRICT_TRANS_TABLES` SQL mode when updating. Seems like the `sequel` gem used by this gem doesn't implicitly update those columns, so when we call insert we get the MySQL error.

I know there has been some discussion about `perfectsched` in general on ConCh and if there are alternatives to explore, but for now this should allow us to finally update Svalbard to MySQL 5.7 in the `docker-compose` and let me use the JSON column introduced in MySQL 5.7.

Passing registry build with gem update: https://buildkite.com/kit-check/registry-service/builds/3042